### PR TITLE
Fix mismatch property

### DIFF
--- a/LanguageServer.Framework/Protocol/Message/DocumentDiagnostic/FullDocumentDiagnosticReport.cs
+++ b/LanguageServer.Framework/Protocol/Message/DocumentDiagnostic/FullDocumentDiagnosticReport.cs
@@ -27,6 +27,6 @@ public class FullDocumentDiagnosticReport
     /**
      * The actual diagnostics.
      */
-    [JsonPropertyName("diagnostics")]
+    [JsonPropertyName("items")]
     public List<Diagnostic> Diagnostics { get; set; } = null!;
 }


### PR DESCRIPTION
lsp specifications:
```ts
/**
 * A diagnostic report with a full set of problems.
 *
 * @since 3.17.0
 */
export interface FullDocumentDiagnosticReport {
	/**
	 * A full document diagnostic report.
	 */
	kind: DocumentDiagnosticReportKind.Full;

	/**
	 * An optional result ID. If provided, it will
	 * be sent on the next diagnostic request for the
	 * same document.
	 */
	resultId?: string;

	/**
	 * The actual items.
	 */
	items: Diagnostic[];
}
```