### PR TITLE
Add missing `ResolveProvider` property + fix inconsistent resolve code

### DIFF
--- a/LanguageServer.Framework/Protocol/Capabilities/Server/Options/CodeActionOptions.cs
+++ b/LanguageServer.Framework/Protocol/Capabilities/Server/Options/CodeActionOptions.cs
@@ -39,6 +39,15 @@ public class CodeActionOptions : WorkDoneProgressOptions
      */
     [JsonPropertyName("documentation")]
     public List<CodeActionKindDocumentation> Documentation { get; set; } = [];
+
+    /**
+	 * The server provides support to resolve additional
+	 * information for a code action.
+	 *
+	 * @since 3.16.0
+	 */
+    [JsonPropertyName("resolveProvider")]
+    public bool ResolveProvider { get; set; }
 }
 
 /**

--- a/LanguageServer.Framework/Server/Handler/CodeActionHandlerBase.cs
+++ b/LanguageServer.Framework/Server/Handler/CodeActionHandlerBase.cs
@@ -23,8 +23,8 @@ public abstract class CodeActionHandlerBase : IJsonHandler
         server.AddRequestHandler("codeAction/resolve", async (message, token) =>
         {
             var request = message.Params!.Deserialize<CodeAction>(server.JsonSerializerOptions)!;
-            await Resolve(request, token);
-            return JsonSerializer.SerializeToDocument(request, server.JsonSerializerOptions);
+            var r = await Resolve(request, token);
+            return JsonSerializer.SerializeToDocument(r, server.JsonSerializerOptions);
         });
     }
 


### PR DESCRIPTION
1) Documentation: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#codeActionOptions
Missing `ResolveProvider` property.

2) Resolve handler from `Completion`:
https://github.com/CppCXY/LanguageServer.Framework/blob/40c30b9b02397f7f53756b589a55b0639c4225de/LanguageServer.Framework/Server/Handler/CompletionHandlerBase.cs#L26-L27

Resolve handler from `CodeAction`:
https://github.com/CppCXY/LanguageServer.Framework/blob/40c30b9b02397f7f53756b589a55b0639c4225de/LanguageServer.Framework/Server/Handler/CodeActionHandlerBase.cs#L26-L27



