### PR TITLE
fix: return explicit null result for shutdown response

### DIFF
--- a/LanguageServer.Framework/Protocol/JsonProtocolContext.cs
+++ b/LanguageServer.Framework/Protocol/JsonProtocolContext.cs
@@ -77,6 +77,7 @@ namespace EmmyLua.LanguageServer.Framework.Protocol;
 [JsonSerializable(typeof(MethodMessage))]
 [JsonSerializable(typeof(RequestMessage))]
 [JsonSerializable(typeof(ResponseMessage))]
+[JsonSerializable(typeof(ShutdownResponseMessage))]
 [JsonSerializable(typeof(NotificationMessage))]
 [JsonSerializable(typeof(ResponseError))]
 [JsonSerializable(typeof(InitializeParams))]

--- a/LanguageServer.Framework/Protocol/JsonRpc/Message.cs
+++ b/LanguageServer.Framework/Protocol/JsonRpc/Message.cs
@@ -74,6 +74,19 @@ public record ResponseMessage(
     [JsonPropertyName("error")] public ResponseError? Error { get; } = Error;
 }
 
+public record ShutdownResponseMessage(
+    StringOrInt Id
+) : Message("2.0")
+{
+    [JsonPropertyName("id")] public StringOrInt Id { get; } = Id;
+
+    [JsonPropertyName("result")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    public JsonDocument? Result { get; } = null;
+    // - When responding to a "shutdown" message, the result must always be null.
+    // - The JsonIgnoreCondition.Never attribute is explicitly set to serialize the JSON as null
+}
+
 public record NotificationMessage(
     string Method,
     JsonDocument? Params

--- a/LanguageServer.Framework/Server/JsonProtocol/JsonProtocolWriter.cs
+++ b/LanguageServer.Framework/Server/JsonProtocol/JsonProtocolWriter.cs
@@ -32,6 +32,12 @@ public class JsonProtocolWriter : IDisposable
         WriteMessage(response);
     }
 
+    public void WriteShutdownResponse(StringOrInt id)
+    {
+        var response = new ShutdownResponseMessage(id);
+        WriteMessage(response);
+    }
+
     public void WriteNotification(NotificationMessage message)
     {
         WriteMessage(message);

--- a/LanguageServer.Framework/Server/LanguageServer.cs
+++ b/LanguageServer.Framework/Server/LanguageServer.cs
@@ -107,7 +107,7 @@ public class LanguageServer : LSPCommunicationBase
                 }
 
                 ShutdownEventDelegate?.Invoke();
-                Writer.WriteResponse(requestMessage.Id, null);
+                Writer.WriteShutdownResponse(requestMessage.Id);
                 return true;
             }
         }


### PR DESCRIPTION
fixes: #19 

To ensure that operations other than “shutdown” messages are not affected, we have made the following changes:
- Added a dedicated response type for shutdown
- Modified the section responsible for generating responses to LSP clients