### PR TITLE
Fix wrong description for `Diagnostic.Tags`

### DIFF
--- a/LanguageServer.Framework/Protocol/Model/Diagnostic/Diagnostic.cs
+++ b/LanguageServer.Framework/Protocol/Model/Diagnostic/Diagnostic.cs
@@ -48,8 +48,7 @@ public class Diagnostic
     public StringOrMarkupContent Message { get; set; } = string.Empty;
 
     /**
-     * An array of related diagnostic information, e.g. when symbol-names within
-     * a scope collide all definitions can be marked via this property.
+     * Additional metadata about the diagnostic.
      */
     [JsonPropertyName("tags")]
     public List<DiagnosticTag>? Tags { get; set; }


### PR DESCRIPTION
The doc comment for `Diagnostic.Tags` seems to have accidentally had `relatedInformation`'s description instead. I changed it to the correct one in the LSP spec.